### PR TITLE
Disable ChangeableSuit gameobject when suits are supposed to be hidden

### DIFF
--- a/ProcessRack.cs
+++ b/ProcessRack.cs
@@ -17,6 +17,7 @@ namespace suitsTerminal
             //suitsTerminal.X("processhiddensuit method");
             component.GetComponent<SuitInfo>().suitTag = "hidden";
             component.disableObject = true;
+            component.gameObject.SetActive(false);
         }
 
         internal static void ProcessHangingSuit(AutoParentToShip component)

--- a/ProcessRack.cs
+++ b/ProcessRack.cs
@@ -17,7 +17,8 @@ namespace suitsTerminal
             //suitsTerminal.X("processhiddensuit method");
             component.GetComponent<SuitInfo>().suitTag = "hidden";
             component.disableObject = true;
-            component.gameObject.SetActive(false);
+            component.gameObject.GetComponentInChildren<SkinnedMeshRenderer>().enabled = false;
+            component.gameObject.GetComponentInChildren<MeshRenderer>().enabled = false;
         }
 
         internal static void ProcessHangingSuit(AutoParentToShip component)


### PR DESCRIPTION
After troubleshooting lags for a long time on my modded gameplays on Linux, I found out that most of the lag I encountered ingame was caused by all the rack suits being rendered even when they are supposed to be hidden.

The suits are far away from the ship, located in 800 -100 0, but are still rendered.

This causes heavy slowdowns especially in heavily modded and VRAM-limited environments.
This issue is not limited to Linux, but is way less noticeable on Windows.

This simple patch should disable the GameObject entirely, allowing the game to run much smoother.


Frame drops before patch (accentuated by OBS x264 encoding)

https://github.com/darmuh/suitsTerminal/assets/34353603/61b8ad58-9d2f-4f51-b1ac-1001d77cfb73

No frame drops after patch

https://github.com/darmuh/suitsTerminal/assets/34353603/7161dd7d-cea0-4348-adc6-a09609a2c5cf


